### PR TITLE
(CTH-289) Add specs for TTL expired message

### DIFF
--- a/cthun/README.md
+++ b/cthun/README.md
@@ -19,6 +19,7 @@ Index
 - [Message Delivery][33] - how the fabric processes and delivers client messages
 - [Destination Report][34] - how the fabric reports the receivers of a message
 - [Error Handling][35] - error handling
+- [Message Expiration][36] - how the fabric reports expired messages
 
 Implementations
 ----
@@ -47,6 +48,7 @@ WebSockets as the underlying wire protocol.
 [33]: delivery.md
 [34]: destination_report.md
 [35]: error_handling.md
+[36]: ttl_expired.md
 [41]: https://github.com/puppetlabs/cthun
 [42]: https://github.com/puppetlabs/cthun-client
 [43]: https://github.com/puppetlabs/cthun-agent

--- a/cthun/delivery.md
+++ b/cthun/delivery.md
@@ -107,6 +107,11 @@ containing the list of URIs it will be sending the message to in the Data Chunk.
 The *destination_report* flag is ignored in case of [inventory requests][2],
 which are addressed directly to the server.
 
+#### Message Expiration
+
+The server must notify the sender of an expired message with a [TTL expired][6]
+message.
+
 #### Error handling
 
 The server must respond to a client with an [error message][4] in case:
@@ -140,3 +145,4 @@ following items:
 [3]: message.md
 [4]: error_handling.md
 [5]: destination_report.md
+[6]: ttl_expired.md

--- a/cthun/ttl_expired.md
+++ b/cthun/ttl_expired.md
@@ -1,0 +1,53 @@
+TTL Expired
+===
+
+When a server processes an expired message, it must send a *ttl_expired* message
+back to its sender and not attempt to deliver it. The message expiration is
+indicated in the *expires* entry of the its envelope.
+
+A message expiration may happen, for example, as a consequece of a series of
+failed delivery attempts:
+
+```
+    client A                    server S                    client B
+       |                           |                           |
+       |        1 message          |                           |
+       |-------------------------->| 2                         |
+       |                           |        3 message          |
+       |                           |-------------X             |
+       |                           |        4 message          |
+       |                           |---------------------X     |
+       |                           |                           |
+       |       5 ttl_expired       |                           |
+       |<--------------------------|                           |
+       |                           |                           |
+```
+
+Client A sends a message to client B through server S (1). S processes (2) and
+tries to deliver it to B, but the message is dropped (3). S does not receives
+the expected ack from B after a certain interval (refer to server operation in
+the [delivery section][1]); S resends the message and restarts the retransmission
+timer (4). Once again, the message is not acknowledged. In the meantime the
+message TTL did expire; as a consequence S sends a *ttl_expired* message back
+to A (5).
+
+ttl_expired messages must have the envelope *message_type* equal to
+`http://puppetlabs.com/ttl_expired`.
+
+The data content is described by the following json-schema:
+
+```
+{
+    "properties" : {
+        "id" : { "type" : "string" },
+    },
+    "required" : ["id"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| id | string | ID of the expired message
+
+[1]: delivery.md


### PR DESCRIPTION
The server must notify the original sender whenever a message being
processed expires. This is done by a ttl_expired message.
