### PR TITLE
(maint) Remove trigger words

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 Cthun Specifications
 ===
 
-The Cthun messaging fabric provides a lightweight communication layer for
-Command and Control.
+The Cthun messaging fabric provides a lightweight communication layer.
 
 This repository describes:
 
- - the [Communications Protocol][1] used by the messaging fabric
- - the [RPC layer][2] implemented by CthunAgent and Pegasus
+ - the [Communications Protocol][1]
+ - the [RPC layer][2]
 
 [1]: cthun/README.md
 [2]: cthun_rpc/README.md

--- a/cthun/README.md
+++ b/cthun/README.md
@@ -31,12 +31,10 @@ WebSockets as the underlying wire protocol.
 
  - [cthun][41] provides a Cthun server implementation in Clojure
  - [cthun-client][42] is a Cthun client library written in C++
- - [cthun-agent][43] is a C&C agent, based on CthunClient
- - [pegasus][44] is a C&C tool that can be used as a controller node; it
- also relies on CthunClient
- - [clj-cthun-message][45] is a library for processing Cthun messages written in
+ - [cthun-agent][43] is an agent used to run puppet, based on CthunClient
+ - [clj-cthun-message][44] is a library for processing Cthun messages written in
  Clojure
- - [clj-cthun-client][46] is a Cthun client Clojure library written in Clojure
+ - [clj-cthun-client][45] is a Cthun client Clojure library written in Clojure
 
 [10]: intro.md
 [11]: terminology.md
@@ -52,6 +50,5 @@ WebSockets as the underlying wire protocol.
 [41]: https://github.com/puppetlabs/cthun
 [42]: https://github.com/puppetlabs/cthun-client
 [43]: https://github.com/puppetlabs/cthun-agent
-[44]: https://github.com/puppetlabs/pegasus
-[45]: https://github.com/puppetlabs/clj-cthun-message
-[46]: https://github.com/puppetlabs/clj-cthun-client
+[44]: https://github.com/puppetlabs/clj-cthun-message
+[45]: https://github.com/puppetlabs/clj-cthun-client

--- a/cthun/terminology.md
+++ b/cthun/terminology.md
@@ -44,8 +44,7 @@ related service provided by the messaging fabric
 
 message exchange that enables a given Cthun framework functionality; it may
 occur at the messaging fabric layer (e.g. session associations) or at client
-layer (e.g. request/response exchange among client nodes to enable a certain C&C
-operation - see Cthun C&C specifications)
+layer (e.g. request/response exchange among client nodes)
 
 ### Re-delivery
 

--- a/cthun_rpc/README.md
+++ b/cthun_rpc/README.md
@@ -1,8 +1,8 @@
 Cthun RPC
 ===
 
-[CthunAgent][1] and [Pegasus][2] provide an RPC framework on top of the Cthun
-messaging fabric. This document describes such layer.
+This document describes an RPC framework on top of the Cthun
+messaging fabric.
 
 Index
 ---
@@ -12,8 +12,6 @@ Index
 - [Actions][12] - action types
 - [Request Response][13] - request/response transaction
 
-[1]: https://github.com/puppetlabs/cthun-agent
-[2]: https://github.com/puppetlabs/pegasus
 [10]: intro.md
 [11]: terminology.md
 [12]: actions.md

--- a/cthun_rpc/actions.md
+++ b/cthun_rpc/actions.md
@@ -18,7 +18,6 @@ the action outcome is available (*notify_outcome* flag); refer to the
 [Request Response][1] section for a detailed description of the transaction
 workflow for both *blocking* and *non-blocking* actions.
 
-*TODO(ale)*: describe action metadata and external modules after Pegasus changes
-for PEG-164
+*TODO(ale)*: describe action metadata and external modules
 
 [1]: request_response.md

--- a/cthun_rpc/intro.md
+++ b/cthun_rpc/intro.md
@@ -9,5 +9,3 @@ In this document we describe:
 
  - actions
  - request/response transactions
-
-*TODO(ale):* update if we enable Pegasus run/bundle/play over Cthun


### PR DESCRIPTION
The specification currently refers to some earlier ideas and earlier
projects that are no longer applicable to what the messaging fabric is
for. This commit removes some of those references to forestall possible
confusion as new readers come on-board to start learning about the
messaging fabric.
