### PR TITLE
(maint) PXP expands to PCP Execution Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The PCP messaging fabric provides a lightweight communication layer.
 This repository describes:
 
  - the [Puppet Communications Protocol (PCP)][1]
- - the [Puppet Execution Protocol (PXP)][2]
+ - the [PCP Execution Protocol (PXP)][2]
 
 [1]: pcp/README.md
 [2]: pxp/README.md

--- a/pxp/README.md
+++ b/pxp/README.md
@@ -1,4 +1,4 @@
-Puppet Execution Protocol (PXP)
+PCP Execution Protocol (PXP)
 ===
 
 This document describes an execution protocol on top of the PCP
@@ -7,7 +7,7 @@ messaging fabric.
 Index
 ---
 
-- [Introduction][10] - overview of the Puppet Execution Protocol
+- [Introduction][10] - overview of the PCP Execution Protocol
 - [Terminology][11] - adopted terminology
 - [Actions][12] - action types
 - [Request Response][13] - request/response transaction

--- a/pxp/actions.md
+++ b/pxp/actions.md
@@ -1,7 +1,7 @@
 Actions
 ===
 
-Within the Puppet Execution Protocol layer, controllers invoke agent capabilities by requesting
+Within the PCP Execution Protocol layer, controllers invoke agent capabilities by requesting
 *actions*. This is done by sending *request* messages to one or more agents.
 Such messages specify the action name, module and input parameters.
 

--- a/pxp/intro.md
+++ b/pxp/intro.md
@@ -1,7 +1,7 @@
 Introduction
 ===
 
-In the Puppet Execution Protocol, agents and controllers are PCP clients that
+In the PCP Execution Protocol, agents and controllers are PCP clients that
 communicate with request/response transactions in order perform remote tasks.
 Such tasks are called *actions*.
 


### PR DESCRIPTION
The PXP acronym actually expands to PCP Execution Protocol, to
indicate that it a layering on top of PCP.

The previous mis-expansion to Puppet Execution Protocol makes it
seem like it's just a way of executing puppet, which though that's
a first use-case, is not the only execution use case we intend
to apply this to.
