### PR TITLE
PCP-195 Widen the scope of the in-reply-to property

### DIFF
--- a/pcp/inventory.md
+++ b/pcp/inventory.md
@@ -52,9 +52,6 @@ json-schema:
 }
 ```
 
-The envelope `content` of inventory response messages must include the
-`in-reply-to` entry, set to the `id` of the inventory request message.
-
 Error Handling
 ---
 


### PR DESCRIPTION
Initially backdoored into pcp-broker's inventory service with this
commit
https://github.com/puppetlabs/pcp-broker/commit/92b66d1cbef9587ebea3a2351627eb4592aa333d
it is now intended that the `in-reply-to` property of the envelope
should be populated for any message that is generated in direct
response to another message.