### PR TITLE
(PCP-337) PCP connection are open after successful Associate

### DIFF
--- a/pcp/versions/1.0/association.md
+++ b/pcp/versions/1.0/association.md
@@ -79,7 +79,8 @@ Client Operation
 ---
 
 Clients must be able to process association responses and change their status
-accordingly.
+accordingly. A client must consider its session with the broker as associated
+only after receiving a successful Associate Response.
 
 In case a client wants a persistent session, it should monitor the
 state of the wire layer connection and attempt to re-establish it if necessary.

--- a/pcp/versions/next/association.md
+++ b/pcp/versions/next/association.md
@@ -79,7 +79,8 @@ Client Operation
 ---
 
 Clients must be able to process association responses and change their status
-accordingly.
+accordingly. A client must consider its session with the broker as associated
+only after receiving a successful Associate Response.
 
 In case a client wants a persistent session, it should monitor the
 state of the wire layer connection and attempt to re-establish it if necessary.


### PR DESCRIPTION
Specifying that PCP connections can be considered fully established only
after the reception of a successful Associate Session reponse.