### PR TITLE
(PCP-242) add unauthorized message

### DIFF
--- a/pcp/versions/next/README.md
+++ b/pcp/versions/next/README.md
@@ -19,9 +19,10 @@ Index
 - [Message Delivery][33] - how the fabric processes and delivers client messages
 - [Destination Report][34] - how the fabric reports the receivers of a message
 - [Error Handling][35] - error handling
-- [Message Expiration][36] - how the fabric reports expired messages
-- [Delivery Guarantees][37] - how the fabric guarantees the delivery of messages
-- [Message Versioning][38] - how the fabric handles message versions
+- [Delivery Authorization][36] - how the fabric reports message delivery authorization failures
+- [Message Expiration][37] - how the fabric reports expired messages
+- [Delivery Guarantees][38] - how the fabric guarantees the delivery of messages
+- [Message Versioning][39] - how the fabric handles message versions
 
 Implementations
 ----
@@ -46,9 +47,10 @@ WebSockets as the underlying wire protocol.
 [33]: delivery.md
 [34]: destination_report.md
 [35]: error_handling.md
-[36]: ttl_expired.md
-[37]: delivery_guarantees.md
-[38]: versioning.md
+[36]: unauthorized.md
+[37]: ttl_expired.md
+[38]: delivery_guarantees.md
+[39]: versioning.md
 [41]: https://github.com/puppetlabs/pcp-broker
 [42]: https://github.com/puppetlabs/cpp-pcp-client
 [43]: https://github.com/puppetlabs/pxp-agent

--- a/pcp/versions/next/delivery.md
+++ b/pcp/versions/next/delivery.md
@@ -107,9 +107,16 @@ containing the list of URIs it will be sending the message to in the Data Chunk.
 The *destination_report* flag is ignored in case of [inventory requests][2],
 which are addressed directly to the broker.
 
+#### Delivery Authorization
+
+The broker must notify the sender with an [unauthorized][6] message in case
+a sender's message fails authorization. The broker must not deliver the
+message to any clients in such case, even if the message delivery to a subset
+of the original targets is authorized.
+
 #### Message Expiration
 
-The broker must notify the sender of an expired message with a [TTL expired][6]
+The broker must notify the sender of an expired message with a [TTL expired][7]
 message.
 
 #### Error handling
@@ -142,4 +149,5 @@ following items:
 [3]: message.md
 [4]: error_handling.md
 [5]: destination_report.md
-[6]: ttl_expired.md
+[6]: unauthorized.md
+[7]: ttl_expired.md

--- a/pcp/versions/next/unauthorized.md
+++ b/pcp/versions/next/unauthorized.md
@@ -1,0 +1,33 @@
+Unauthorized
+===
+
+When a broker declines to deliver a message because it fails authorization,
+it must send an *unauthorized* message back to the original message sender.
+The broker must not deliver the message to any clients in such case, even
+if the message delivery to a subset of the original targets is authorized.
+
+A message is only delivered by the broker if it passes authorization. In
+the opposite case the situation is quite simple:
+
+```
+    client A                    broker B
+       |                           |
+       |         1 message         |
+       |-------------------------->| 2
+       |                           |
+       |      3 unauthorized       |
+       |<--------------------------|
+       |                           |
+       |                           |
+```
+
+Client A sends a message through the broker B (1). B receives the message,
+checks its authorization, which fails (2). As a result B sends the
+*unauthorized* message (3) to A.
+
+*unauthorized* messages must have the envelope *message_type* equal to
+`http://puppetlabs.com/unauthorized`.
+The *in_reply_to* field of the unauthorized message envelope contains
+the ID of the message which failed the authorization.
+
+There is no data chunk in the message.


### PR DESCRIPTION
The behavior of the broker in case it refuses to deliver a message because it fails authorization was unspecified, the implementation just silently dropped the message.
In this commit we define that the broker should send a new type of message - unauthorized - to the sender of the message which failed the authorization.