### PR TITLE
(PCP-654) Define version 2 of PCP

### DIFF
--- a/pcp/versions/2.0/README.md
+++ b/pcp/versions/2.0/README.md
@@ -1,0 +1,48 @@
+Puppet Communications Protocol (PCP)
+===
+
+This document describes the PCP framework and its communications protocol.
+
+Index
+----
+
+- [Introduction][10] - overview of the PCP framework
+- [Terminology][11] - definitions used by the Puppet communications protocol
+
+##### Syntax
+- [Message][20] - JSON-based message format
+- [URI][21] - PCP URI format
+
+##### Semantics
+- [Session][31] - initialise connections
+- [Inventory][32] - inventory service and transaction
+- [Message Delivery][33] - how the fabric processes and delivers client messages
+- [Error Handling][34] - error handling
+- [Delivery Guarantees][35] - how the fabric guarantees the delivery of messages
+- [Message Versioning][36] - how the fabric handles message versions
+
+Implementations
+----
+
+The following projects follow the PCP specifications described here, using
+WebSockets as the underlying wire protocol.
+
+ - [pcp-broker][41] provides a PCP broker implementation in Clojure
+ - [cpp-pcp-client][42] is a PCP client library written in C++
+ - [pxp-agent][43] is a PXP agent based on cpp-pcp-client, that offers a Puppet module
+ - [clj-pcp-client][44] is a PCP client library written in Clojure
+
+[10]: intro.md
+[11]: terminology.md
+[20]: message.md
+[21]: uri.md
+[31]: session.md
+[32]: inventory.md
+[33]: delivery.md
+[34]: error_handling.md
+[35]: delivery_guarantees.md
+[36]: versioning.md
+[41]: https://github.com/puppetlabs/pcp-broker
+[42]: https://github.com/puppetlabs/cpp-pcp-client
+[43]: https://github.com/puppetlabs/pxp-agent
+[44]: https://github.com/puppetlabs/clj-pcp-client

--- a/pcp/versions/2.0/delivery.md
+++ b/pcp/versions/2.0/delivery.md
@@ -1,0 +1,76 @@
+Message Delivery
+===
+
+In this section, we define the behavior of PCP broker when delivering messages.
+
+### Client to client messages
+
+Consider the following example. Client A and client C are connected to a broker B.
+A is identified by the URI _pcp://client_a/controller_ and C by _pcp://client_b/agent_.
+A wishes to send a [message][3] via B to C.
+
+```
+    client A                    broker B                    client C
+       |                           |                           |
+       |        1 message          |                           |
+       |-------------------------->|                           |
+       |                           | 2                         |
+       |                           |        3 message          |
+       |                           |-------------------------->|
+
+```
+
+**A** sends a message to **B**, specifying a URI in the message's
+*target* field, _pcp://client_b/agent_ (1).
+
+**B** receives the message from **A**, parses it and determines that it is valid.
+**B** inspects the *target* field in the message and prepares to deliver
+the message to the supplied URI, _pcp://client_b/agent_ in this particular case (2).
+
+**B** determines that the URI points to **C**. It then delivers the message to
+**C** (3).
+
+### Client to broker messages
+
+Consider the following example. Client A is connected to a broker B. A is identified
+by the URI _pcp://client_a/controller_. A wishes to perform an inventory query and
+thus needs to send a message to B (refer to the [inventory][1] section).
+
+```
+    client A                    broker B
+       |                           |
+       |        1 message          |
+       |-------------------------->|
+       |                           | 2
+       |        3 message          |
+       |<--------------------------|
+
+```
+
+**A** sends a message to **B**, omitting the *target* field (1).
+
+**B** receives the message from **A**, parses it and determines that it is valid.
+**B** inspects the *target* field in the message and determines that
+the message was directed at itself.
+**B** performs a broker specific task, determined by the value supplied in the
+*message_type* field in the [message][3] (2).
+**B** constructs a resulting message and sends it to **A** using the URI supplied
+in the original message's *sender* field, _pcp://client_a/contoller_ (3).
+
+### Broker Operation
+
+From the above examples, it is clear that PCP Brokers must perform a number of
+operations to deliver a message. In this section we describe the operation
+requirements for the broker.
+
+#### Error handling
+
+The broker must respond to a client with an [error message][2] in case:
+
+- the message cannot be parsed (see [message][3])
+- the message does not match the message schema (see [message][3])
+- the recipient of the *target* entry is not registered in the broker
+
+[1]: inventory.md
+[2]: error_handling.md
+[3]: message.md

--- a/pcp/versions/2.0/delivery_guarantees.md
+++ b/pcp/versions/2.0/delivery_guarantees.md
@@ -1,0 +1,4 @@
+Delivery Guarantees
+===
+
+The fabric does not offer any message delivery guarantee.

--- a/pcp/versions/2.0/error_handling.md
+++ b/pcp/versions/2.0/error_handling.md
@@ -1,0 +1,27 @@
+Error Messages
+===
+
+When an invalid or undeliverable message has been sent to a broker, the broker
+must respond with an error message.
+
+The *data* entry of error messages are described by the following json-schema:
+
+```
+{
+    "properties" : {
+        "id" : { "type" : "string" },
+        "description" : { "type" : "string" }
+    },
+    "required" : ["description"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| id | string | ID of the received message that originated the error (optional)
+| description | string | error description
+
+An error message must have the *message_type* entry equal to:
+
+`http://puppetlabs.com/error_message`

--- a/pcp/versions/2.0/intro.md
+++ b/pcp/versions/2.0/intro.md
@@ -1,0 +1,51 @@
+Introduction
+===
+
+Actors
+---
+
+#### Broker
+
+The PCP Broker is the entity that enables inter-client communication. It
+provides the following capabilities.
+
+##### Message Delivery
+
+Messages are delivered in a point to point manner. A client sends a message
+to a broker and specifies a recipient. The broker will attempt to
+deliver the message to its intended target. If the message cannot be delivered
+immediately, the broker will drop the message and inform the sender with an
+error message.
+
+##### Inventory
+
+When the broker receives an [inventory][1] request, it will return the list of
+[PCP URIs][2] of clients that currently have a [session][3] with the broker.
+
+(*Caveat*) The current implementation of the inventory service is purposefully
+simplistic. When the requirements have been finalised, the inventory service
+may depend on puppetdb.
+
+#### Clients
+
+Clients are addressable entities connected to a PCP Broker which can send
+and receive messages.
+
+What is covered by PCP specifications
+---
+
+The PCP specification define the communications protocol used by the nodes
+within a PCP framework. It covers the message syntax, PCP URI format, the
+semantics of the services described above, and error handling.
+
+What will come
+---
+
+ - RBAC
+ - distributed message fabric / HA (multi broker)
+ - puppetdb integration (improve the inventory service)
+ - node classifier integration
+
+[1]: inventory.md
+[2]: uri.md
+[3]: association.md

--- a/pcp/versions/2.0/inventory.md
+++ b/pcp/versions/2.0/inventory.md
@@ -1,0 +1,73 @@
+Inventory
+===
+
+The inventory service provides the list of nodes of a given type currently
+registered in the messaging fabric.
+
+Message Flow
+---
+
+A client node that wants an inventory list of a PCP broker must 1) be
+connected to it (refer to [sessions][1]) and 2) send an inventory
+request message to a PCP broker.
+
+In case the request is processed successfully, the broker will reply with an
+inventory response message.
+
+Inventory Messages
+---
+
+Inventory request and response messages must have the *message_type*
+entry respectively equal to `http://puppetlabs.com/inventory_request` and
+`http://puppetlabs.com/inventory_response`.
+
+The *data* entry of an inventory request message is an array of URIs,
+described by the following json-schema:
+
+```
+{
+    "type" : "array",
+    "items" : { "type" : "string",
+                "pattern" : "^pcp://[^/]*/[^/]+$" }
+}
+```
+
+The *data* entry of an inventory response message is an array of URIs,
+described by the same json-schema.
+
+Wildcard URI's
+---
+
+When constructing URI's for inventory requests both the *Common name* and
+*Client type* fields can be replaced by a wild card. When the broker processes
+such a URI it must expand the wild card to include all clients.
+
+A URI that expands to all types of clients that present the *Common name* _bob.com_
+will look like:
+
+`pcp://bob.com/*`
+
+A URI that expands to all clients that define their type as _agent_ will look like:
+
+`pcp://*/agent`
+
+A URI that expands to all clients will look like:
+
+`pcp://*/*`
+
+Error Handling
+---
+
+In case of an error during the processing of the inventory list, the broker must
+reply with an error message as described in the [error handling][2] section.
+The *message_type* entry of the JSON data `content` must be equal to the
+inventory request one mentioned above.
+
+Server Operation
+---
+
+The broker must expand the wildcard and determine the list of URI's of all matching
+clients.
+
+[1]: session.md
+[2]: error_handling.md

--- a/pcp/versions/2.0/message.md
+++ b/pcp/versions/2.0/message.md
@@ -1,0 +1,31 @@
+PCP Messages
+===
+
+PCP messages are a JSON object.
+
+The content of an envelope is a JSON document that must match the following
+JSON schema:
+
+```
+{
+    "properties" : {
+        "id" : { "type" : string" },
+        "message_type" : { "type" : "string" },
+        "target" : { "type" : "string",
+                     "pattern" : "^pcp://[^/]*/[^/]+$" },
+        "sender" : { "type" : "string",
+                     "pattern" : "^pcp://[^/]*/[^/]+$" },
+        "data" : {}
+    },
+    "required" : ["id", "message_type"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| id | string | string representation of 128-bit unique identifier of the message
+| message_type | string | schema name that identifies the type of message and the schema used to validate its data entry (if any)
+| target | string | PCP URI indicating the recipient
+| sender | string | PCP URI indicating the endpoint node (broker or client node) that sent the message
+| data | any | the data entry, containing an arbitrary json type determined by the *message_type* (most likely string, array, or object)

--- a/pcp/versions/2.0/session.md
+++ b/pcp/versions/2.0/session.md
@@ -1,0 +1,49 @@
+Sessions
+===
+
+PCP clients must establish a session with a broker before they can use
+its capabilities. A session is an authenticated connection between a client and
+broker that the broker has associated with a [client URI][1].
+
+A [client URI][1] is established based on the client's common name and the
+requested *client_type*. A *client_type* is requested by appending it as a path
+element to the underlying connection URI. If the resulting URI is not
+authorized by the broker, the connection will be closed.
+
+Example: given a broker designated at the URI `wss://broker.example.com/pcp`,
+a session using the `controller` *client_type* would be established by
+connecting to the URI `wss://broker.example.com/pcp/controller`. Given a client
+authenticated as `client01`, the client session would then be established with
+the associated [client URI][1] `pcp://client01/controller`.
+
+If no *client_type* is appended to the path, the broker may select a default.
+
+Should a session already be associated with the given [client URI][1], the
+broker should disconnect the older connection, and consider the
+newly-associated session to be authoritative for that URI.
+
+Broker Operation
+---
+
+Once a connection is established, the broker must extract the common name from
+the client SSL certificate used to establish the connection and use it to
+generate the [client URI][1] associated with that connection.
+
+In case the underlying wire connection drops, the broker must guarantee that the
+client will be disassociated, meaning that the [client URI][1] will no longer map to
+its underlying connection (e.g. WebSocket connection).
+
+The broker must keep track of the associated clients and must be
+able to obtain the current status of their wire connections. That is necessary
+in order to perform delivery and inventory operations.
+
+Client Operation
+---
+
+Clients should append their desired *client_type* to the URI used to establish
+the underlying wire connection.
+
+In case a client wants a persistent session, it should monitor the
+state of the wire layer connection and attempt to re-establish it if necessary.
+
+[1]: uri.md

--- a/pcp/versions/2.0/terminology.md
+++ b/pcp/versions/2.0/terminology.md
@@ -1,0 +1,59 @@
+Terminology
+===
+
+### PCP Framework
+
+communications system that provides capabilities such as: message delivery
+and inventory queries.
+
+### Client
+
+addressable entity that uses the Puppet Communications Protocol
+described in this document
+
+### Uniform Resource Indicator (URI)
+
+string that identifies a client within a PCP framework; URIs are used to address
+nodes and are made up of three parts, a scheme name, a common name and a type. For
+Example: pcp://bob.com/controller
+
+### Client common name
+
+the name of a client determined by the common name in a client certificate
+
+### Client type
+
+a text label that identifies the role of a given node within a PCP framework;
+the "server" type is the reserved label for PCP brokers
+
+### Broker
+
+entity that provides inter client communication
+
+### Message
+
+data sent between nodes; it includes the actual payload and the metadata that
+enables the delivery
+
+### Message Delivery
+
+the process of sending a message to the recipient node; also the related
+service provided by the messaging fabric
+
+### Transaction
+
+message exchange that enables a given PCP framework functionality; it may
+occur at the messaging fabric layer (e.g. inventory request/response) or at
+client layer (e.g. request/response exchange among client nodes)
+
+### Session
+
+an active connection between broker and client
+
+### Inventory
+
+service that provides the list of nodes registered to the messaging fabric
+
+### Schema
+
+JSON schema used to validate the format of message parts

--- a/pcp/versions/2.0/uri.md
+++ b/pcp/versions/2.0/uri.md
@@ -1,0 +1,24 @@
+PCP Uniform Resource Indicator
+===
+
+A PCP URI is a text string used to identify an addressable client within a PCP
+framework.
+
+The PCP URI format is:
+
+`pcp://<common_name>/<client_type>`
+
+The components of a PCP URI are:
+
+- *PCP scheme name* `pcp`, followed by a colon and a double slash
+- *Common name* The name presented in the client's SSL certificate (e.g. bob.com)
+- *Client type* The type of the client (e.g. agent)
+
+The "server" label is reserved type, as it indicates the node type of PCP brokers.
+
+### Broker addressing
+
+A client may address the broker it is currently connected to by using the short
+hand:
+
+`pcp:///server`

--- a/pcp/versions/2.0/versioning.md
+++ b/pcp/versions/2.0/versioning.md
@@ -1,0 +1,94 @@
+Message Versioning
+===
+
+This section describes how the Puppet Communications Protocol handles clients
+attempting to communicate using different versions of the protocol. Here, we
+will assume that WebSocket provides the wire communication layer; a WebSocket
+URI will convey the version information when a PCP connection is attempted.
+
+### How clients and the pcp-broker determine protocol version
+
+When a pcp-broker starts up it will mount a URI for each of the
+versions it supports. Consider the following scenario:
+
+A pcp-broker, broker.example.com, supports versions 1, 2 and 3 of the PCP. It
+will mount the following URI's.
+
+- wss://broker.example.com/v1
+- wss://broker.example.com/v2
+- wss://broker.example.com/v3
+
+A client that wishes to communicate using version 2 of the protocol will connect
+to the version 2 URI, `wss://broker.example.com/v2`. After establishing this
+connection all communications MUST happen using version 2 of the protocol.
+
+No discovery mechanism for supported PCP version is provided, so clients are
+expected to support configuration of the version they use to communicate.
+
+Two versions of the protocol can be compatible to the point where translation
+from one to the other is possible. The following two sections describe the
+intended behaviour of the pcp-broker in those cases.
+
+### Two protocol versions are compatible
+
+When two versions of the protocol are declared as compatible, it is the
+responsibility of the pcp-broker to translate a message from the one version
+to the other.
+
+Consider the following scenario:
+
+Client A connects to the pcp-broker and states its capability to send and
+receive messages using version 1 of the PCP. Client B connects to the
+pcp-broker states its capability to send and receive messages using version 2
+of the PCP. How the client and broker determines version capabilities are up the
+client and broker implementations.
+
+Version 1 and 2 are considered compatible versions of the protocol.
+
+Client A sends a message intended for Client B. In this case, the pcp-broker
+MUST translate the message from version 1 to version 2.
+
+### Two protocol versions are not compatible
+
+When two version of the protocol are declared as not compatible, it is the
+responsibility of the pcp-broker to send a
+[version_error](#version_error-messages) message to the sender.
+
+Consider the following scenario:
+
+Client A connects to the pcp-broker and states its capability to send and
+receive messages using version 1 of the PCP. Client B connects to the
+pcp-broker states its capability to send and receive messages using version 3
+of the PCP. How the client and broker determines version capabilities are up the
+client and broker implementations.
+
+Version 1 and 3 are considered not compatible versions of the protocol.
+
+Client A sends a message intended for Client B. In this case, the pcp-broker
+MUST respond with a [version_error](#version_error-messages) message to Client
+A.
+
+### version_error messages
+
+A `version_error` message must have the envelope *message_type* equal to
+`http://puppetlabs.com/version_error`.
+
+The data content is described by the following JSON schema:
+
+```
+{
+    "properties" : {
+        "id" : { "type" : string" },
+        "target" : { "type" : "string" },
+        "reason" : { "type" : "string" }
+    },
+    "required" : ["id", "target", "reason"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| id | string | id of the message this message is in response to
+| target | string | PCP URI the message was targeted at
+| reason | string | reason a version_error message was sent


### PR DESCRIPTION
Defines a version 2 of PCP that
- removes the session association exchange
- removes the `expires` field and delayed message delivery
- changes `targets` to `target` (taking a single string), removing
  multi-target messages
- removes `destination_report`
- removes debug chunks
- changes to a text-based JSON message format

It assumes an underlying wire format that specifies overall message
size, and the ability to put additional connection data in the URI when
establishing a connection with a broker.