### PR TITLE
(maint) Propose removing inventory version

### DIFF
--- a/pcp/versions/2.0/inventory.md
+++ b/pcp/versions/2.0/inventory.md
@@ -52,17 +52,12 @@ For inventory responses:
     "uris" : { "type" : "array",
                "items" : { "type" : "string",
                            "pattern" : "^pcp://[^/]*/[^/]+$" }
-    },
-    "version": { "type": "integer"}
+    }
   },
-  "required" : ["uris", "version"],
+  "required" : ["uris"],
   "additionalProperties" : false
 }
 ```
-
-In reference to the schema above, the `version` field is an interger equal to
-the number of changes (client connections and disconnections) that have
-occurred on the inventory since broker startup.
 
 For inventory updates:
 * The *message_type* field must equal `http://puppetlabs.com/inventory_update`
@@ -70,7 +65,6 @@ For inventory updates:
 ```
 {
   "properties": {
-    "version": { "type": "integer"},
     "changes": { "type": "array",
                  "items": {
                   "properties": {
@@ -80,19 +74,14 @@ For inventory updates:
                                 "description": "A representation of a connection or disconnection. 1 for connection, -1 for disconnection"}
                   }
                 }
-    }
-  }
-  "required": ["changes", "version"],
+  "required": ["changes"],
   "additionalProperties": false
 }
 ```
 
-In the schema above, the `version` field is as described in the "inventory
-responses" section. The `changes` field is specified as an array so that
+In the schema above, the `changes` field is specified as an array so that
 inventory updates may batch multiple changes to reduce network chatter.
-Batching is optional and the batching stragegy is up to the implementation. The
-version reflected in an inventory update message must equal the inventory
-version *prior* to the accompanying list of changes.
+Batching is optional and the batching strategy is up to the implementation.
 
 
 Wildcard URI's


### PR DESCRIPTION
Inventory version was intended to ensure that inventory updates would
not be missed or arive out-of-order. However, they didn't promise any
consistency when connection between client and broker is lost.

TCP guarantees in-order-delivery. That should be sufficient to ensure
that - over a single TCP session - no inventory updates are missed or
arrive out-of-order. As such, inventory version seems redundant.