### PR TITLE
(maint) Fix link to PCP v2 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The PCP messaging fabric provides a lightweight communication layer.
 
 This repository describes:
 
- - the Puppet Communications Protocol (PCP): [v1.0][pcp_1_0], [next][pcp_next]
+ - the Puppet Communications Protocol (PCP): [v1.0][pcp_1_0], [v2.0][pcp_2_0]
  - the PCP Execution Protocol (PXP): [v1.0][pxp_1_0], [next][pxp_next]
 
 ## Maintenance
@@ -20,6 +20,6 @@ Tickets: File bug tickets at https://tickets.puppet.com/browse/PCP and add the
 
 [contributing]: CONTRIBUTING.md
 [pcp_1_0]: pcp/versions/1.0/README.md
-[pcp_next]: pcp/versions/next/README.md
+[pcp_2_0]: pcp/versions/2.0/README.md
 [pxp_1_0]: pxp/versions/1.0/README.md
 [pxp_next]: pxp/versions/next/README.md


### PR DESCRIPTION
Trivial link fix.