### PR TITLE
Adds a duplicate_response message type

### DIFF
--- a/pxp/versions/1.1/README.md
+++ b/pxp/versions/1.1/README.md
@@ -1,0 +1,20 @@
+PCP Execution Protocol (PXP)
+===
+
+This document describes an execution protocol on top of the PCP
+messaging fabric.
+
+Index
+---
+
+- [Introduction][10] - overview of the PCP Execution Protocol
+- [Terminology][11] - adopted terminology
+- [Actions][12] - action types
+- [Request Response][13] - request/response transaction
+- [Transaction Status][14] - action for querying the status of remote tasks
+
+[10]: intro.md
+[11]: terminology.md
+[12]: actions.md
+[13]: request_response.md
+[14]: transaction_status.md

--- a/pxp/versions/1.1/actions.md
+++ b/pxp/versions/1.1/actions.md
@@ -1,0 +1,19 @@
+Actions
+===
+
+Within the PCP Execution Protocol layer, controllers invoke agent capabilities
+by requesting *actions*. This is done by sending *request* messages to one or
+more agents. Such messages specify the action name, module and input parameters.
+
+Actions related to a given application are grouped together in *modules*; for
+instance, a `puppet` module may provide the `run` and `status` actions.
+
+Action requests can be *blocking* or *non-blocking*; that changes the way the
+action outcome is referred and stored. Please refer to the [Request/Response][1]
+and [Transaction Status][2] sections for more details.
+
+To inform the requester controller about the outcome of the requested action,
+the agent replies with a *response* message.
+
+[1]: request_response.md
+[2]: transaction_status.md

--- a/pxp/versions/1.1/intro.md
+++ b/pxp/versions/1.1/intro.md
@@ -1,0 +1,11 @@
+Introduction
+===
+
+In the PCP Execution Protocol, agents and controllers are PCP clients that
+communicate with request/response transactions in order perform remote tasks.
+Such tasks are called *actions*.
+
+In this document we describe:
+
+ - actions
+ - request/response transactions

--- a/pxp/versions/1.1/request_response.md
+++ b/pxp/versions/1.1/request_response.md
@@ -1,0 +1,268 @@
+Request/Response transactions
+===
+
+In this section, we describe the request/response message exchange between
+client endpoints.
+
+### Blocking Action - Message Flow
+
+The following figure shows an example of a *blocking* request/response
+transaction, for a `puppet status` action.
+
+```
+    controller C                agent A
+       |                           |
+       |  `puppet status` request  |
+     1 |-------------------------->|
+       |                           | puppet status 2
+       |                           |   |
+       |                           |   |
+       |                           |   |
+       |          response         |   V 3
+     4 |<--------------------------|
+       |                           |
+```
+
+The controller **C** and the agent **A** are registered in the same PCP
+framework. **C** sends a `puppet status` *blocking request* to **A** (1).
+As soon as the request is received and validated, **A** starts the execution of
+`puppet status` by relying on the logic of the puppet module (2).
+
+Once the action terminates (3), **A** sends back to **B** a *blocking response*
+containing the `puppet status` outcome (4).
+
+Note that the transaction does not employ acknowledgment messages. And there
+are no constraints regarding the controller operation; **C** can decide whether
+or to not to implement a response timeout.
+
+Also, note that **A** must reply with a:
+ - *PCP protocol error message* in case the request message contains a bad data chunk (see [PCP Error Handling][1])
+ - *RPC error message* if it fails to execute the requested action (see [RPC Error Message](#error-message))
+
+### Non-blocking Action - Message Flow
+
+This time, **C** wants to executes a `puppet run` action in **A**. Since such
+action may take some time to complete, **C** decides to use a *non-blocking*
+transaction in order to receive an immediate confirmation of its execution
+start.
+
+```
+    controller C                agent A
+       |                           |
+       |    `puppet run` request   |
+     1 |-------------------------->|
+       |    provisional response   | puppet run 2
+     3 |<--------------------------|   |
+       |                           |   |
+       |                           |   |
+       |                           |   |
+       |                           |   |
+       |                           |   |
+       |                           |   |
+       |    `puppet run` response  |   V 4
+     5 |<--------------------------|
+       |                           |
+```
+
+**C** sends to **A** a `puppet run` *non-blocking request* (1). After validating
+the request message, **A** starts the requested action (2) and immediately sends
+back to **C** a *provisional response* containing the action job ID (3).
+
+The `puppet run` job terminates (4) and, since **C** requested to be notified
+with the outcome of the job (*notify_outcome* was flagged in the
+*non-blocking request* message), **A** sends back to **C** a
+*non-blocking response* containing the job output and possible errors of the
+executed action (5).
+
+Note that if the *transaction_id* of the *non-blocking request* has been used
+in a previous *non-blocking request*, a *duplicate response* will be sent in
+place of a *provisional response* and the *notify_outcome* flag will be ignored.
+
+### Message types
+
+The following list gives the *message_type* string for the Request Response
+transaction messages:
+
+| message | *message_type*
+|---------|---------------
+| blocking request | `http://puppetlabs.com/rpc_blocking_request`
+| blocking response | `http://puppetlabs.com/rpc_blocking_response`
+| non-blocking request | `http://puppetlabs.com/rpc_non_blocking_request`
+| non-blocking response | `http://puppetlabs.com/rpc_non_blocking_response`
+| provisional response | `http://puppetlabs.com/rpc_provisional_response`
+| duplicate response | `http://puppetlabs.com/rpc_duplicate_response`
+| error | `http://puppetlabs.com/rpc_error_message`
+
+### Message Format
+
+In this section we describe the data content format of request/response
+messages.
+
+##### Blocking Request
+
+```
+{
+    "properties" : {
+        "transaction_id" : { "type" : "string" },
+        "module" : { "type" : "string" },
+        "action" : { "type" : "string" },
+        "params" : { "type" : "object" }
+    },
+    "required" : ["transaction_id", module", "action"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| transaction_id | string | free format id of the request/response transaction
+| module | string | name of the module that includes the requested action
+| action | string | name of the requested action withing its submodule
+| params | object | input parameters (optional)
+
+##### Blocking Response
+
+The results of the requested action should be included in the *results* object;
+its schema is action-specific. *transaction_id* is the other required entry.
+
+```
+{
+    "properties" : {
+        "transaction_id" : { "type" : "string" },
+        "results" : { "type" : "object" }
+    },
+    "required" : ["transaction_id", "results"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| transaction_id | string | free format id of the request/response transaction
+| results | object | action results in action-specific format
+
+##### Non-blocking Request
+
+```
+{
+    "properties" : {
+        "transaction_id" : { "type" : "string" },
+        "notify_outcome" : { "type" : "bool" },
+        "module" : { "type" : "string" },
+        "action" : { "type" : "string" },
+        "params" : { "type" : "object" }
+    },
+    "required" : ["transaction_id", "notify_outcome", module", "action"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| transaction_id | string | free format id of the request/response transaction
+| notify_outcome | bool | if true, the agent must send a non-blocking response containing the action outcome, once its execution completes
+| module | string | name of the module that includes the requested action
+| action | string | name of the requested action withing its submodule
+| params | object | input parameters (optional)
+
+##### Non-blocking Response
+
+The results of the requested action should be included in the *results* object;
+its schema is action-specific. *transaction_id* is the other required entry.
+
+```
+{
+    "properties" : {
+        "transaction_id" : { "type" : "string" },
+        "results" : { "type" : "object" }
+    },
+    "required" : ["transaction_id", "job_id", "results"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| transaction_id | string | free format id of the request/response transaction
+| results | object | action results in action-specific format
+
+##### Provisional Response
+
+Such message indicates that requested action has successfully started.
+The *transaction_id* should be used as a reference to the remote action.
+
+```
+{
+    "properties" : {
+        "transaction_id" : { "type" : "string" }
+    },
+    "required" : ["transaction_id"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| transaction_id | string | free format id of the request/response transaction
+
+##### Duplicate Response
+
+Such message indicates that the requested action has previously been started,
+and is either running or has already been completed but not yet wiped from
+memory.
+
+```
+{
+    "properties" : {
+        "transaction_id" : { "type" : "string" }
+    },
+    "required" : ["transaction_id"],
+    "additionalProperties" : false
+}
+
+| name | type | description
+|------|------|------------
+| transaction_id | string | free format id of the request/response transaction
+
+### Error Message
+
+An *RPC error message* follows the structure of PCP Error messages, as
+described [here][1], plus the mandatory *transaction_id* field. The
+*message_type* is the one specified above. The format is:
+
+```
+{
+    "properties" : {
+        "transaction_id" : { "type" : "string" },
+        "id" : { "type" : "string" },
+        "description" : { "type" : "string" }
+    },
+    "required" : ["transaction_id", "id", "description"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| transaction_id | string | free format id of the request/response transaction
+| id | string | ID of the received request that originated the error
+| description | string | error description
+
+### Error Handling
+
+The agent should reply with an *RPC error message* in case of:
+ - unknown module
+ - unknown action
+ - failure when starting the action execution
+ - failure during the action execution
+
+The agent should reply with an *PCP error message* in case of:
+ - no data content
+ - invalid data content
+Note that in such cases, it is not possible to retrieve a *transaction_id* and
+create an *RPC error message*.
+
+The controller error handling operation should handle messages at both the PXP and
+PCP layers, by covering the above cases.
+
+[1]: ../pcp/error_handling.md

--- a/pxp/versions/1.1/terminology.md
+++ b/pxp/versions/1.1/terminology.md
@@ -1,0 +1,43 @@
+Terminology
+===
+
+The following terms rely on the definitions outlined in the
+[PCP terminology][1] section.
+
+### Agent
+
+PCP client that interprets requests and performs actions
+
+### Controller
+
+PCP client that can request the RPC capabilities offered by agents and process
+their outcome
+
+### Request
+
+PCP message by which a controller requires a capability offered by one or more
+agents
+
+### Response
+
+PCP message by which an agent replies to a controller, containing the outcome
+of a request
+
+### Action
+
+a processing capability offered by an agent that may be invoked by an RPC
+request
+
+### Blocking action
+
+once a *blocking action* is requested by a controller, the agent replies with a
+response message containing its outcome after its execution completes
+
+### Non-blocking action
+
+action for which the agent replies with a provisional response message
+containing a pointer to the action outcome as soon as the action execution
+starts; when the action terminates, its outcome will be sent back to the
+controller in case it requested that by flagging the *notify_outcome* field
+
+[1]: ../pcp/terminology.md

--- a/pxp/versions/1.1/transaction_status.md
+++ b/pxp/versions/1.1/transaction_status.md
@@ -1,0 +1,63 @@
+Transaction Status
+===
+
+Agents must implement a *transaction status* [module][1] that includes a *query*
+action. Such action must provide information regarding *non-blocking*
+requests previously issued:
+ - the status of the action requested in a given transaction ("running", "success", "failure", or "unknown");
+ - in case that action has completed its execution, the action outcome (stdout, stderr, and exit code).
+
+Note that PCP client nodes refer to requested actions by the transaction id of
+the request; see the [Request/Response][2] section for more details.
+
+### Request
+
+Transaction status requests must be *blocking*. They must follow the schemas
+presented in the [Request/Response][2] section, where the *module* and *action*
+entries must be set to, respectively, `status` and `query`; also the *params*
+entry must comply with the following JSON schema:
+
+```
+{
+    "properties" : {
+        "transaction_id" : { "type" : "string" }
+    },
+    "required" : ["transaction_id"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| transaction_id | string | the id of the transaction the controller is interested in
+
+
+### Blocking Response
+
+Transaction status responses must have the *results* entry complying with the
+following schema:
+
+```
+{
+    "properties" : {
+        "transaction_id" : { "type" : "string" },
+        "status" : { "enum" : [ "unknown", "success", "failure", "running" ] },
+        "stdout" : { "type" : "string" },
+        "stderr" : { "type" : "string" },
+        "exitcode" : { "type" : "integer" }
+    },
+    "required" : ["transaction_id", "status"],
+    "additionalProperties" : false
+}
+```
+
+| name | type | description
+|------|------|------------
+| transaction_id | string | the id of the queried transaction
+| status | string | state of the action ("success", "failure", "running") or "unknown" in case an unknown transaction_id was specified in the request
+| stdout | string | output of the action, in case it did complete
+| stderr | string | possible errors of the action, in case it did complete
+| exitcode | integer | the exit code of the action, in case it did complete
+
+[1]: actions.md
+[2]: request_response.md


### PR DESCRIPTION
Adds a duplicate response message type for non-blocking transactions, to
be sent in place of a provisional response if the transaction id of the
request has previously been used.