### PR TITLE
(maint) Document inventory subscription lifetime

### DIFF
--- a/pcp/versions/2.0/session.md
+++ b/pcp/versions/2.0/session.md
@@ -22,6 +22,9 @@ Should a session already be associated with the given [client URI][1], the
 broker should disconnect the older connection, and consider the
 newly-associated session to be authoritative for that URI.
 
+A session ends when the connection is lost. Inventory subscriptions are not
+maintained across sessions.
+
 Broker Operation
 ---
 


### PR DESCRIPTION
Add note that inventory subscriptions are reset if the connection is
lost, i.e. session ends.